### PR TITLE
Switch from circe-generic to circe-derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val V = new {
   val scala212 = "2.12.6"
   val enumeratum = "1.5.12"
   val circe = "0.9.0"
+  val circeDerivation = "0.9.0-M4"
   val cats = "1.0.1"
   val monix = "2.3.0"
 }
@@ -81,8 +82,7 @@ lazy val jsonrpc = project
       "com.beachape" %% "enumeratum-circe" % "1.5.15",
       "com.lihaoyi" %% "pprint" % "0.5.3",
       "io.circe" %% "circe-core" % V.circe,
-      "io.circe" %% "circe-generic" % V.circe,
-      "io.circe" %% "circe-generic-extras" % V.circe,
+      "io.circe" %% "circe-derivation" % V.circeDerivation,
       "io.circe" %% "circe-parser" % V.circe,
       "io.monix" %% "monix" % V.monix,
       "org.typelevel" %% "cats-core" % V.cats

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/CancelParams.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/CancelParams.scala
@@ -1,6 +1,6 @@
 package scala.meta.jsonrpc
 
 import io.circe.Json
-import io.circe.generic.JsonCodec
+import io.circe.derivation.JsonCodec
 
 @JsonCodec case class CancelParams(id: Json)

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/ErrorObject.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/ErrorObject.scala
@@ -1,7 +1,7 @@
 package scala.meta.jsonrpc
 
 import io.circe.Json
-import io.circe.generic.JsonCodec
+import io.circe.derivation.JsonCodec
 
 @JsonCodec case class ErrorObject(
     code: ErrorCode,

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/Message.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/Message.scala
@@ -3,11 +3,12 @@ package scala.meta.jsonrpc
 import monix.eval.Task
 import io.circe.Json
 import io.circe.Decoder
-import io.circe.generic.JsonCodec
-import cats.syntax.either._
 import io.circe.Encoder
 import io.circe.JsonObject
+import io.circe.derivation.JsonCodec
 import io.circe.syntax._
+
+import cats.syntax.either._
 
 sealed trait Message
 object Message {

--- a/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
@@ -1,7 +1,7 @@
 package scala.meta.lsp
 
 import io.circe.Json
-import io.circe.generic.JsonCodec
+import io.circe.derivation.JsonCodec
 
 /**
  * Parameters and types used in the `initialize` message.

--- a/lsp4s/src/main/scala/scala/meta/lsp/Types.scala
+++ b/lsp4s/src/main/scala/scala/meta/lsp/Types.scala
@@ -4,7 +4,7 @@ import cats.syntax.either._
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.Json
-import io.circe.generic.JsonCodec
+import io.circe.derivation.JsonCodec
 
 /**
  * Position in a text document expressed as zero-based line and character offset.


### PR DESCRIPTION
Switches from circe-generic to circe-derivation, which is the recommended module for doing generic derivations for Circe. It has the added (and nice) benefit of _not_ relying of Shapeless, so this helps to address https://github.com/scalameta/lsp4s/issues/8 and https://github.com/ensime/ensime-server/pull/1951.