### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,11 @@ jobs:
     - env: TEST="scalafmt"
       script: ./bin/scalafmt --test
     - env: TEST="2.11"
-      script:
-        - sbt ++2.11.12 lsp4s/test
-        - sbt ++2.11.12 jsonrpc/test
-    - env: TEST="sbt test"
-      script:
-        - sbt test
+      script: sbt ++2.11.12 test
+    - env: TEST="2.12"
+      script: sbt test
     - stage: release
-      script: sbt ci-release
+      script: travis_wait 60 sbt ci-release
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 inThisBuild(
   List(
-    dynverSonatypeSnapshots := true, // TODO: remove after https://github.com/olafurpg/sbt-ci-release/pull/7 is released
     organization := "org.scalameta",
     homepage := Some(url("https://github.com/scalameta/lsp4s")),
     publishMavenStyle := true,
@@ -62,13 +61,14 @@ name := "lsp4sRoot"
 skip in publish := true
 
 lazy val V = new {
-  val scala211 = "2.11.11"
+  val scala211 = "2.11.12"
   val scala212 = "2.12.6"
-  val enumeratum = "1.5.12"
-  val circe = "0.9.0"
+  val enumeratum = "1.5.13"
+  val enumeratumCirce = "1.5.17"
+  val circe = "0.9.3"
   val circeDerivation = "0.9.0-M4"
-  val cats = "1.0.1"
-  val monix = "2.3.0"
+  val cats = "1.1.0"
+  val monix = "2.3.3"
 }
 
 lazy val jsonrpc = project
@@ -79,8 +79,7 @@ lazy val jsonrpc = project
     libraryDependencies ++= List(
       "com.outr" %% "scribe" % "2.5.0",
       "com.beachape" %% "enumeratum" % V.enumeratum,
-      "com.beachape" %% "enumeratum-circe" % "1.5.15",
-      "com.lihaoyi" %% "pprint" % "0.5.3",
+      "com.beachape" %% "enumeratum-circe" % V.enumeratumCirce,
       "io.circe" %% "circe-core" % V.circe,
       "io.circe" %% "circe-derivation" % V.circeDerivation,
       "io.circe" %% "circe-parser" % V.circe,

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/Connection.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/Connection.scala
@@ -1,0 +1,49 @@
+package scala.meta.jsonrpc
+
+import monix.execution.Cancelable
+import monix.execution.CancelableFuture
+import monix.execution.Scheduler
+import scribe.Logger
+import scribe.LoggerSupport
+
+/**
+ * A connection with another JSON-RPC entity.
+ *
+ * @param client used to send requests/notification to the other entity.
+ * @param server server on this side listening to input streams from the other entity.
+ */
+final case class Connection(
+    client: LanguageClient,
+    server: CancelableFuture[Unit]
+) extends Cancelable {
+  override def cancel(): Unit = server.cancel()
+}
+
+object Connection {
+
+  def simple(io: InputOutput, name: String)(
+      f: LanguageClient => Services
+  )(implicit s: Scheduler): Connection =
+    Connection(
+      io,
+      Logger(s"$name-server"),
+      Logger(s"$name-client")
+    )(f)
+
+  def apply(
+      io: InputOutput,
+      serverLogger: LoggerSupport,
+      clientLogger: LoggerSupport
+  )(
+      f: LanguageClient => Services
+  )(implicit s: Scheduler): Connection = {
+    val messages =
+      BaseProtocolMessage.fromInputStream(io.in, serverLogger)
+    val client =
+      LanguageClient.fromOutputStream(io.out, clientLogger)
+    val server =
+      new LanguageServer(messages, client, f(client), s, serverLogger)
+    Connection(client, server.startTask.executeWithFork.runAsync)
+  }
+
+}

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/Endpoint.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/Endpoint.scala
@@ -3,6 +3,8 @@ package scala.meta.jsonrpc
 import io.circe.Decoder
 import io.circe.Encoder
 import monix.eval.Task
+import monix.execution.Ack
+import scala.concurrent.Future
 
 class Endpoint[A: Decoder: Encoder, B: Decoder: Encoder](val method: String) {
   def encoderA: Encoder[A] = implicitly
@@ -16,7 +18,7 @@ class Endpoint[A: Decoder: Encoder, B: Decoder: Encoder](val method: String) {
     client.request[A, B](method, request)
   def notify(
       notification: A
-  )(implicit client: JsonRpcClient, ev: B =:= Unit): Unit =
+  )(implicit client: JsonRpcClient): Future[Ack] =
     client.notify[A](method, notification)
 }
 

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/InputOutput.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/InputOutput.scala
@@ -1,0 +1,7 @@
+package scala.meta.jsonrpc
+
+import java.io.InputStream
+import java.io.OutputStream
+
+/** Wrapper around a pair of input/output streams. */
+final class InputOutput(val in: InputStream, val out: OutputStream)

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/LanguageClient.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/LanguageClient.scala
@@ -85,3 +85,8 @@ class LanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport)
     }
   }
 }
+
+object LanguageClient {
+  def fromOutputStream(out: OutputStream, logger: LoggerSupport) =
+    new LanguageClient(Observer.fromOutputStream(out, logger), logger)
+}

--- a/jsonrpc/src/main/scala/scala/meta/jsonrpc/testkit/ClientServer.scala
+++ b/jsonrpc/src/main/scala/scala/meta/jsonrpc/testkit/ClientServer.scala
@@ -1,0 +1,39 @@
+package scala.meta.jsonrpc.testkit
+
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import monix.execution.Scheduler
+import scala.meta.jsonrpc.Connection
+import scala.meta.jsonrpc.InputOutput
+import scala.meta.jsonrpc.LanguageClient
+import scala.meta.jsonrpc.Services
+
+final case class ClientServer(client: Connection, server: Connection)
+
+object ClientServer {
+
+  /**
+   * Instantiate bi-directional communication between a client and server.
+   *
+   * Useful for testing purposes.
+   *
+   * @param clientServices services implemented by the client.
+   * @param serverServices services implemented by the server.
+   * @param s the scheduler to run all services.
+   */
+  def apply(
+      clientServices: LanguageClient => Services,
+      serverServices: LanguageClient => Services
+  )(implicit s: Scheduler): ClientServer = {
+    val inClient = new PipedInputStream()
+    val inServer = new PipedInputStream()
+    val outClient = new PipedOutputStream(inServer)
+    val outServer = new PipedOutputStream(inClient)
+    val clientIO = new InputOutput(inClient, outClient)
+    val serverIO = new InputOutput(inServer, outServer)
+    val client = Connection.simple(clientIO, "client")(clientServices)
+    val server = Connection.simple(serverIO, "server")(serverServices)
+    new ClientServer(client, server)
+  }
+
+}

--- a/jsonrpc/src/test/scala/tests/BaseProtocolMessageSuite.scala
+++ b/jsonrpc/src/test/scala/tests/BaseProtocolMessageSuite.scala
@@ -1,0 +1,103 @@
+package tests
+
+import java.nio.ByteBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import io.circe.syntax._
+import minitest.SimpleTestSuite
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+import scala.meta.jsonrpc._
+import scribe.Logger
+
+object BaseProtocolMessageSuite extends SimpleTestSuite {
+  private val request = Request("method", Some("params".asJson), RequestId(1))
+  private val message = BaseProtocolMessage(request)
+  private val byteArray = MessageWriter.write(message).array()
+  private val byteArrayDouble = byteArray ++ byteArray
+  private def bytes = ByteBuffer.wrap(byteArray)
+
+  test("toString") {
+    assertEquals(
+      message.toString.replaceAll("\r\n", "\n"),
+      """|Content-Length: 62
+         |
+         |{"method":"method","params":"params","id":"1","jsonrpc":"2.0"}""".stripMargin
+    )
+  }
+
+  private val s = TestScheduler()
+  def await[T](f: Task[T]): T = {
+    val a = f.runAsync(s)
+    while (s.tickOne()) ()
+    Await.result(a, Duration("5s"))
+  }
+
+  // Emulates a sequence of chunks and returns the parsed protocol messages.
+  def parse(buffers: List[ByteBuffer]): List[BaseProtocolMessage] = {
+    val buf = List.newBuilder[BaseProtocolMessage]
+    val t = BaseProtocolMessage
+      .fromByteBuffers(Observable(buffers: _*), Logger.root)
+      // NOTE(olafur) toListL will not work as expected here, it will send onComplete
+      // for the first onNext, even when a single ByteBuffer can contain multiple
+      // messages
+      .foreachL(buf += _)
+    await(t)
+    buf.result()
+  }
+
+  0.to(4).foreach { i =>
+    test(s"parse-$i") {
+      val (buffers, messages) = 1.to(i).toList.map(_ => bytes -> message).unzip
+      assertEquals(parse(buffers), messages)
+    }
+  }
+
+  def checkTwoMessages(name: String, buffers: List[ByteBuffer]): Unit = {
+    test(name) {
+      val obtained = parse(buffers)
+      val expected = List(message, message)
+      assertEquals(obtained, expected)
+    }
+  }
+
+  def array: ByteBuffer = ByteBuffer.wrap(byteArray)
+  def take(n: Int): ByteBuffer = ByteBuffer.wrap(byteArray.take(n))
+  def drop(n: Int): ByteBuffer = ByteBuffer.wrap(byteArray.drop(n))
+
+  checkTwoMessages(
+    "combined",
+    ByteBuffer.wrap(byteArrayDouble) ::
+      Nil
+  )
+
+  checkTwoMessages(
+    "chunked",
+    take(10) ::
+      drop(10) ::
+      array ::
+      Nil
+  )
+
+  checkTwoMessages(
+    "chunked2",
+    take(10) ::
+      ByteBuffer.wrap(drop(10).array() ++ take(10).array()) ::
+      drop(10) ::
+      Nil
+  )
+
+  test("chunked-property") {
+    0.to(byteArrayDouble.length).foreach { i =>
+      // Split the message at offset `i` and emit two chunks
+      val buffers =
+        ByteBuffer.wrap(byteArrayDouble.take(i)) ::
+          ByteBuffer.wrap(byteArrayDouble.drop(i)) ::
+          Nil
+      val obtained = parse(buffers)
+      val expected = List(message, message)
+      assertEquals(obtained, expected)
+    }
+  }
+}

--- a/jsonrpc/src/test/scala/tests/PingPongSuite.scala
+++ b/jsonrpc/src/test/scala/tests/PingPongSuite.scala
@@ -1,0 +1,72 @@
+package tests
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import minitest.SimpleTestSuite
+import monix.execution.Cancelable
+import scala.meta.jsonrpc._
+import monix.execution.Scheduler.Implicits.global
+import scala.collection.JavaConverters._
+import scala.meta.jsonrpc.testkit._
+import scribe.Logger
+
+/**
+ * Tests the following sequence:
+ *
+ * C         S
+ * |  Ping   |
+ * | ------> |
+ * |  Pong   |
+ * | <------ |
+ * |         |
+ * |  Ping   |
+ * | <------ |
+ * |  Pong   |
+ * | ------> |
+ * |         |
+ * |  Hello  |
+ * | ----->> |
+ * | <<<---- |
+ *
+ * Where:
+ * ---> indicates notification
+ * -->> indicates request
+ * ->>> indicates response
+ */
+object PingPongSuite extends SimpleTestSuite {
+
+  private val Ping = Endpoint.notification[String]("ping")
+  private val Pong = Endpoint.notification[String]("pong")
+  private val Hello = Endpoint.request[String, String]("hello")
+
+  testAsync("ping pong") {
+    val pongs = new ConcurrentLinkedQueue[String]()
+    val services = Services
+      .empty(Logger.root)
+      .request(Hello) { msg =>
+        s"$msg, World!"
+      }
+      .notification(Pong) { message =>
+        assert(pongs.add(message))
+      }
+    val pongBack: LanguageClient => Services = { client =>
+      services.notification(Ping) { message =>
+        Pong.notify(message.replace("Ping", "Pong"))(client)
+      }
+    }
+    val ClientServer(client, server) =
+      ClientServer(pongBack, pongBack)
+    for {
+      _ <- Ping.notify("Ping from client")(client.client)
+      _ <- Ping.notify("Ping from server")(server.client)
+      Right(obtained) <- Hello.request("Hello")(client.client).runAsync
+    } yield {
+      assertEquals(obtained, "Hello, World!")
+      val obtainedPongs = pongs.asScala.toList.sorted
+      val expectedPongs =
+        List("client", "server").map(name => s"Pong from $name")
+      Cancelable.cancelAll(client :: server :: Nil)
+      assertEquals(obtainedPongs, expectedPongs)
+    }
+  }
+
+}

--- a/jsonrpc/src/test/scala/tests/ServicesSuite.scala
+++ b/jsonrpc/src/test/scala/tests/ServicesSuite.scala
@@ -1,0 +1,15 @@
+package tests
+
+import minitest.SimpleTestSuite
+import scribe.Logger
+import scala.meta.jsonrpc._
+
+object ServicesSuite extends SimpleTestSuite {
+  test("duplicate method throws IllegalArgumentException") {
+    val duplicate = Endpoint.notification[Int]("duplicate")
+    val base = Services.empty(Logger.root).notification(duplicate)(_ => ())
+    intercept[IllegalArgumentException] {
+      base.notification(duplicate)(_ => ())
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.1.0")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.1.2")


### PR DESCRIPTION
This PR brings in the ping-pong tests from the unmerged PR #4 and also BaseProtocolMessageSuite from the metals repo. While working on the unit tests, I found some low-hanging fruit improvements to the API to simplify management of input/output pairs.

cc/ @andyscott 