### PR TITLE
Parameter processId to initialize is optional

### DIFF
--- a/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
@@ -11,7 +11,7 @@ import io.circe.derivation.JsonCodec
      * The process Id of the parent process that started
      * the server.
      */
-    processId: Long,
+    processId: Option[Long],
     /**
      * The rootPath of the workspace. Is null
      * if no folder is open.


### PR DESCRIPTION
According to the specification, the processId parameter is optional.

Some LSP clients (for example, vim-lsp) do not provide this parameter.
Currently, lsp4s fails to initialize for those clients. Making this
parameter optional allows initialization to continue.

This parameter appears to be unused, so only the type has been changed.

https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#initialize