### PR TITLE
rootPath is nullable and so must be an Option

### DIFF
--- a/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/scala/meta/lsp/Commands.scala
@@ -16,7 +16,7 @@ import io.circe.derivation.annotations.JsonCodec
      * The rootPath of the workspace. Is null
      * if no folder is open.
      */
-    rootPath: String,
+    rootPath: Option[String],
     /**
      * The capabilities provided by the client (editor)
      */


### PR DESCRIPTION
initialize `params/rootPath` is nullable so must be an `Option`